### PR TITLE
The redirect is using the wrong variable name for the routes

### DIFF
--- a/src/Controller/EntityCreateController.php
+++ b/src/Controller/EntityCreateController.php
@@ -98,7 +98,7 @@ class EntityCreateController extends ControllerBase {
     if (count($bundles) == 1) {
       $bundle_names = array_keys($bundles);
       $bundle_name = reset($bundle_names);
-      return $this->redirect($form_route_name, [$bundle_key => $bundle_name]);
+      return $this->redirect($form_route_name, [$bundle_type => $bundle_name]);
     }
     // Prepare the #bundles array for the template.
     $bundles = $this->loadBundleDescriptions($bundles, $bundle_type);


### PR DESCRIPTION
example:

```
bundle_entity_type = "ceb_test_content_type",
keys {
  bundle = "type"
},
```
