### PR TITLE
Don't require entity type to be translatable to show revisions

### DIFF
--- a/src/Controller/RevisionControllerTrait.php
+++ b/src/Controller/RevisionControllerTrait.php
@@ -132,8 +132,11 @@ trait RevisionControllerTrait {
     foreach ($entity_revisions as $revision) {
       $row = [];
       /** @var \Drupal\Core\Entity\ContentEntityInterface $revision */
-      if ($revision->hasTranslation($langcode) && $revision->getTranslation($langcode)
-          ->isRevisionTranslationAffected()
+      if (empty($translatable)) {
+        $translatable = $revision->getEntityType()->isTranslatable();
+      }
+      if (!$translatable || ($revision->hasTranslation($langcode) && $revision->getTranslation($langcode)
+          ->isRevisionTranslationAffected())
       ) {
         $row[] = $this->getRevisionDescription($revision, $revision->isDefaultRevision());
 


### PR DESCRIPTION
Currently there is a test to determine if the current site language code matches the revision to be displayed in the overview table. This poses a problem if the entity type is not translatable, though. Added a test to determine the revision's entity type translation support, and test on that, first.
